### PR TITLE
Add resque implementation

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,13 @@ import (
 )
 
 func main() {
+	var (
+		reviewer = reviewerFunc(lintReviewer)
+		queue    = newResqueEnqueuer("high")
+	)
+
+	goworker.Register("GoReviewJob", newGoReviewJob(reviewer, queue))
+
 	if err := goworker.Work(); err != nil {
 		log.Error(err)
 	}

--- a/resque.go
+++ b/resque.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/benmanns/goworker"
+)
+
+type Enqueuer interface {
+	Enqueue(className string, args ...interface{}) error
+}
+
+type enqueuerFunc func(className string, args ...interface{}) error
+
+func (f enqueuerFunc) Enqueue(className string, args ...interface{}) error {
+	return f(className, args...)
+}
+
+// newResqueEnqueuer returns an Enqueuer
+// which will push jobs onto the specified queue.
+func newResqueEnqueuer(queue string) Enqueuer {
+	return enqueuerFunc(func(className string, args ...interface{}) error {
+		payload := goworker.Payload{
+			Class: className,
+			Args:  args,
+		}
+
+		data, err := json.Marshal(payload)
+		if err != nil {
+			return err
+		}
+
+		conn, err := goworker.GetConn()
+		if err != nil {
+			return err
+		}
+		defer goworker.PutConn(conn)
+
+		_, err = conn.Do(
+			"LPUSH",
+			fmt.Sprintf("%squeue:%s", goworker.Namespace(), queue),
+			data,
+		)
+		return err
+	})
+}

--- a/review.go
+++ b/review.go
@@ -12,10 +12,6 @@ func (f reviewerFunc) Review(p GoReviewJobPayload) ([]violation, error) {
 	return f(p)
 }
 
-type Enqueuer interface {
-	Enqueue(className string, args ...interface{}) error
-}
-
 // newGoReviewJob returns a function which satisfies
 // the workerFunc type of goworker.
 func newGoReviewJob(r Reviewer, queue Enqueuer) func(string, ...interface{}) error {

--- a/review_test.go
+++ b/review_test.go
@@ -7,12 +7,6 @@ import (
 	"github.com/benmanns/goworker"
 )
 
-type enqueuerFunc func(className string, args ...interface{}) error
-
-func (f enqueuerFunc) Enqueue(className string, args ...interface{}) error {
-	return f(className, args...)
-}
-
 var (
 	successReviewer reviewerFunc = func(GoReviewJobPayload) ([]violation, error) {
 		return []violation{fixtureViolation}, nil

--- a/types.go
+++ b/types.go
@@ -48,7 +48,7 @@ func newGoReviewJobPayload(args []interface{}) (GoReviewJobPayload, error) {
 // of the data in the first argument of a CompletedFileReviewJob.
 type CompletedFileReviewJobPayload struct {
 	FileInfo
-	Violations []violation `json:"violation"`
+	Violations []violation `json:"violations"`
 }
 
 type violation struct {


### PR DESCRIPTION
This adds a resque implemenation of an Enqueuer,
and wires up the main worker process
to handle GoReviewJobs.

In theory, this should be sufficient
to apply golint to a Go pull request,
assuming Hound created the necessary GoReviewJob.