### PR TITLE
PullRequestNumber field in job data is int

### DIFF
--- a/types.go
+++ b/types.go
@@ -11,7 +11,7 @@ import (
 type FileInfo struct {
 	Name              string `json:"filename"`
 	CommitSHA         string `json:"commit_sha"`
-	PullRequestNumber string `json:"pull_request_number"`
+	PullRequestNumber int    `json:"pull_request_number"`
 	Patch             string `json:"patch"`
 }
 

--- a/types_test.go
+++ b/types_test.go
@@ -10,7 +10,7 @@ var (
 		FileInfo: FileInfo{
 			Name:              "main.go",
 			CommitSHA:         "6f6fe29be600e0511c24ff6985d3ca32025b6e99",
-			PullRequestNumber: "1",
+			PullRequestNumber: 1,
 			Patch:             "patch-data",
 		},
 		Content: "file-content",
@@ -19,7 +19,7 @@ var (
 	fixtureReviewJobArg = map[string]interface{}{
 		"filename":            "main.go",
 		"commit_sha":          "6f6fe29be600e0511c24ff6985d3ca32025b6e99",
-		"pull_request_number": "1",
+		"pull_request_number": 1,
 		"patch":               "patch-data",
 		"content":             "file-content",
 	}


### PR DESCRIPTION
I had previously assumed all fields were strings
in the data sent via Resque,
but the pull request number is in fact an int.

This fix is enough to run a successful
end-to-end test with hound.