### PR TITLE
Mention golint in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ hound-go
 
 [![Build Status](https://circleci.com/gh/thoughtbot/hound-go/tree/master.svg?style=svg)](https://circleci.com/gh/thoughtbot/hound-go/tree/master)
 
-Go review service for Hound.
+Go review service for Hound. Backed by [golint](https://github.com/golang/lint).
 
 Contributing
 ------------


### PR DESCRIPTION
So that it reads the same way as the other READMEs for thoughtbot hound
services.

As was discussed here: https://github.com/thoughtbot/hound/pull/926